### PR TITLE
remove the obsolete namelist parameter: sfc_coupled

### DIFF
--- a/DP_TC/RUN_DP_TC_v3_shiemom.csh
+++ b/DP_TC/RUN_DP_TC_v3_shiemom.csh
@@ -536,7 +536,6 @@ cat >! input.nml <<EOF
        xkzm_h         = 1.0
        cloud_gfdl     = .true.
        do_ocean       = .false.
-       sfc_coupled    = .true.
        fixed_date     = .true.
        fixed_solhr    = .true.
        fixed_sollat   = .true.


### PR DESCRIPTION
This parameter is now managed within the code and cannot be specified by the user anymore.