### PR TITLE
Fix missing "tables" in file copy

### DIFF
--- a/DP_TC/RUN_DP_TC_v3_shiemom.csh
+++ b/DP_TC/RUN_DP_TC_v3_shiemom.csh
@@ -275,7 +275,7 @@ EOF
 cat ${DIAG_TABLE} >> diag_table
 
 # copy over the other tables and executable
-cp ${RUN_DIR}/data_table data_table
+cp ${RUN_DIR}/tables/data_table data_table
 cp ${FIELD_TABLE} field_table
 cp $executable .
 


### PR DESCRIPTION
Include "tables" when copying related files to the work directory